### PR TITLE
Replace fixed list of devices by a BLE scan

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,18 +16,19 @@ Software:
 1) Copy config.h.example into config.h and update seetings according to your environment:
 - WLAN SSID and password
 - MQTT Server address
-- MAC address(es) of your Xiaomi Mi Plant sensor(s)
 
 2) Open ino sketch in Arduino, compile & upload. 
 
 ## Measuring interval
 
-The ESP32 will perform a single connection attempt to the Xiaomi Mi Plant sensor, read the sensor data & push it to the MQTT server. The ESP32 will enter deep sleep mode after all sensors have been read and sleep for X minutes before repeating the exercise...
+The ESP32 will scan BLE devices to find Xiaomi Mi Plant sensors. Then it perform a single connection attempt to the Xiaomi Mi Plant sensor, read the sensor data & push it to the MQTT server. The ESP32 will enter deep sleep mode after all sensors have been read and sleep for X minutes before repeating the exercise...
 Battery level is read every Xth wakeup.
 Up to X attempst per sensor are performed when reading the data fails.
 
 ## Configuration
 
+- MAX_DEVICES - the maximum number of devices that can be scanned at once
+- BLE_SCAN_DURATION - duration of the initial BLE scan used to look for Xiaomi Mi Plant sensors
 - SLEEP_DURATION - how long should the device sleep between sensor reads?
 - EMERGENCY_HIBERNATE - how long after wakeup should the device forcefully go to sleep (e.g. when something gets stuck)?
 - BATTERY_INTERVAL - how ofter should the battery status be read?

--- a/flora/config.h.example
+++ b/flora/config.h.example
@@ -1,10 +1,8 @@
+// Max Number of devices monitored
+const int MAX_DEVICES = 20;
 
-// array of different xiaomi flora MAC addresses
-char* FLORA_DEVICES[] = {
-    "C4:7C:8D:67:11:11", 
-    "C4:7C:8D:67:22:22", 
-    "C4:7C:8D:67:33:33"
-};
+// Max duration of BLE scan (in seconds)
+const int BLE_SCAN_DURATION = 10;
 
 // sleep between to runs in seconds
 #define SLEEP_DURATION 30 * 60


### PR DESCRIPTION
The list of devices is now dynamic.  The BLE scan has a duration of BLE_SCAN_DURATION. It looks for devices with root UUID matching 0xfe95 (flora device identifier).
Then the initial processing is applied on each device.