### PR TITLE
Add platformio configuration.

### DIFF
--- a/flora/platformio.ini
+++ b/flora/platformio.ini
@@ -1,0 +1,25 @@
+;PlatformIO Project Configuration File
+;
+;   Build options: build flags, source filter
+;   Upload options: custom upload port, speed and extra flags
+;   Library options: dependencies, extra library storages
+;   Advanced options: extra scripting
+;
+; Please visit documentation for the other options and examples
+; https://docs.platformio.org/page/projectconf.html
+
+
+[platformio]
+src_dir = .
+
+[env:default]
+platform = espressif32
+board = lolin32
+board_build.partitions = no_ota.csv
+framework = arduino
+monitor_speed = 115200
+upload_speed = 1000000
+lib_deps =
+  PubSubClient
+
+


### PR DESCRIPTION
This merge request add a platformio.ini file.

Platformio allows you to build the source code from the command line, automatically downloading the required toolchains, libraries and upload tools. This allows you, for example, to run an automated compile on travis-ci for example. It also takes the guesswork out of configuring the Arduino IDE, as things like the hardware, OTA configuration, library versions can all be specified.

You can install it on Linux as follows (example for debian):
  sudo apt-get install python-pip
  sudo pip install platformio
Then compile the source code & upload the binary by running
 pio run -t upload
